### PR TITLE
[Feat] ShareView 기반 이미지 반출 기능 구현

### DIFF
--- a/Projects/App/Sources/MyApp.swift
+++ b/Projects/App/Sources/MyApp.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Feature
 
 @main
 struct MyApp: App {

--- a/Projects/Common/Sources/Extension/CustomActivityViewController.swift
+++ b/Projects/Common/Sources/Extension/CustomActivityViewController.swift
@@ -1,0 +1,19 @@
+//
+//  CustomActivityViewController.swift
+//  Common
+//
+//  Created by Ha Jong Myeong on 11/8/23.
+//  Copyright © 2023 com.pivoters. All rights reserved.
+//
+
+import SwiftUI
+
+// UIActivityViewController 서브클래스
+class CustomActivityViewController: UIActivityViewController {
+    var onDismiss: (() -> Void)? // 사라질 때 호출될 클로저
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        onDismiss?()
+    }
+}

--- a/Projects/Common/Sources/Extension/View+.swift
+++ b/Projects/Common/Sources/Extension/View+.swift
@@ -1,0 +1,28 @@
+//
+//  View+.swift
+//  Common
+//
+//  Created by Ha Jong Myeong on 11/8/23.
+//  Copyright © 2023 com.pivoters. All rights reserved.
+//
+
+import SwiftUI
+
+public extension View {
+    /// 공유 시트를 표시하기 위한 메소드
+    func showShareSheet(with activityItems: [Any], isSharing: Binding<Bool>) {
+        let activityVC = CustomActivityViewController(activityItems: activityItems, applicationActivities: nil)
+
+        // 공유 화면을 닫을 때, 상태값을 false로 설정
+        activityVC.onDismiss = {
+            isSharing.wrappedValue = false
+        }
+
+        // 현재 활성화된 UIWindowScene을 가져와 activityVC를 모달로 표시
+        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene {
+            if let rootViewController = windowScene.windows.first(where: { $0.isKeyWindow })?.rootViewController {
+                rootViewController.present(activityVC, animated: true)
+            }
+        }
+    }
+}

--- a/Projects/Common/Sources/Extension/View+.swift
+++ b/Projects/Common/Sources/Extension/View+.swift
@@ -25,4 +25,22 @@ public extension View {
             }
         }
     }
+
+    /// SwiftUI 뷰의 스냅샷을 캡처하는 메소드
+    func snapshot() -> UIImage? {
+        let controller = UIHostingController(rootView: self)
+
+        let view = controller.view
+        let targetSize = CGSize(width: 200, height: 200)
+        view?.frame = CGRect(origin: .zero, size: targetSize)
+        view?.backgroundColor = .clear
+
+        view?.layoutIfNeeded()
+
+        // 내부적으로 렌더링 수행
+        let renderer = UIGraphicsImageRenderer(size: targetSize)
+        return renderer.image { _ in
+            view?.drawHierarchy(in: controller.view.bounds, afterScreenUpdates: true)
+        }
+    }
 }

--- a/Projects/Common/Sources/Helper/ImageMetadataProvider.swift
+++ b/Projects/Common/Sources/Helper/ImageMetadataProvider.swift
@@ -1,0 +1,44 @@
+//
+//  File.swift
+//  Common
+//
+//  Created by Ha Jong Myeong on 11/9/23.
+//  Copyright © 2023 com.pivoters. All rights reserved.
+//
+
+import Foundation
+import UIKit
+import LinkPresentation
+
+public class ImageMetadataProvider: UIActivityItemProvider {
+  var image: UIImage
+
+  public override var item: Any {
+      return self.image
+  }
+
+  public override init(placeholderItem: Any) {
+    guard let image = placeholderItem as? UIImage else {
+      fatalError("DEBUG ::: Couldn't create image from provided item")
+    }
+
+    self.image = image
+    super.init(placeholderItem: placeholderItem)
+  }
+
+  @available(iOS 13.0, *)
+  public override func activityViewControllerLinkMetadata(_ activityViewController: UIActivityViewController) -> LPLinkMetadata? {
+
+    let metadata = LPLinkMetadata()
+    metadata.title = "Result Image"
+
+    var thumbnail: NSSecureCoding = NSNull()
+    if let imageData = self.image.pngData() {
+      thumbnail = NSData(data: imageData)
+    }
+
+    metadata.imageProvider = NSItemProvider(item: thumbnail, typeIdentifier: "public.png")
+
+    return metadata
+  }
+}

--- a/Projects/Common/Sources/Helper/ImageMetadataProvider.swift
+++ b/Projects/Common/Sources/Helper/ImageMetadataProvider.swift
@@ -31,8 +31,8 @@ public class ImageMetadataProvider: UIActivityItemProvider {
         _ activityViewController: UIActivityViewController
     ) -> LPLinkMetadata? {
         let metadata = LPLinkMetadata()
-        metadata.title = "Result Image" // 팀 이름으로 변경예정
-
+        metadata.title = "Titles" // 팀 이름으로 변경 예정
+        metadata.originalURL = URL(fileURLWithPath: "Subtitles") // 포메이션 이름으로 변경 예정
         var thumbnail: NSSecureCoding = NSNull()
         if let imageData = self.image.pngData() {
             thumbnail = NSData(data: imageData)

--- a/Projects/Common/Sources/Helper/ImageMetadataProvider.swift
+++ b/Projects/Common/Sources/Helper/ImageMetadataProvider.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  ImageMetadataProvider.swift
 //  Common
 //
 //  Created by Ha Jong Myeong on 11/9/23.
@@ -11,34 +11,35 @@ import UIKit
 import LinkPresentation
 
 public class ImageMetadataProvider: UIActivityItemProvider {
-  var image: UIImage
+    var image: UIImage
 
-  public override var item: Any {
-      return self.image
-  }
-
-  public override init(placeholderItem: Any) {
-    guard let image = placeholderItem as? UIImage else {
-      fatalError("DEBUG ::: Couldn't create image from provided item")
+    public override var item: Any {
+        return self.image
     }
 
-    self.image = image
-    super.init(placeholderItem: placeholderItem)
-  }
+    public override init(placeholderItem: Any) {
+        guard let image = placeholderItem as? UIImage else {
+            fatalError("DEBUG ::: Couldn't create image from provided item")
+        }
 
-  @available(iOS 13.0, *)
-  public override func activityViewControllerLinkMetadata(_ activityViewController: UIActivityViewController) -> LPLinkMetadata? {
-
-    let metadata = LPLinkMetadata()
-    metadata.title = "Result Image"
-
-    var thumbnail: NSSecureCoding = NSNull()
-    if let imageData = self.image.pngData() {
-      thumbnail = NSData(data: imageData)
+        self.image = image
+        super.init(placeholderItem: placeholderItem)
     }
 
-    metadata.imageProvider = NSItemProvider(item: thumbnail, typeIdentifier: "public.png")
+    @available(iOS 13.0, *)
+    public override func activityViewControllerLinkMetadata(
+        _ activityViewController: UIActivityViewController
+    ) -> LPLinkMetadata? {
+        let metadata = LPLinkMetadata()
+        metadata.title = "Result Image" // 팀 이름으로 변경예정
 
-    return metadata
-  }
+        var thumbnail: NSSecureCoding = NSNull()
+        if let imageData = self.image.pngData() {
+            thumbnail = NSData(data: imageData)
+        }
+
+        metadata.imageProvider = NSItemProvider(item: thumbnail, typeIdentifier: "public.png")
+
+        return metadata
+    }
 }

--- a/Projects/Feature/Sources/MainView.swift
+++ b/Projects/Feature/Sources/MainView.swift
@@ -27,7 +27,7 @@ public struct MainView: View {
                 TeamInfo(team: someTeam)
                     .blur(radius: isSharing ? 10 : 0)
                 if isSharing {
-                    ShareView()
+                    ShareImage()
                         .padding(.bottom, 400)
                 }
             }
@@ -46,16 +46,30 @@ public struct MainView: View {
 // 공유 버튼
 struct ShareButton: View {
     @Binding var isSharing: Bool
-    // 임시 링크, 이미지로 대체 예정
-    let itemsToShare = ["https://www.youtube.com/watch?v=Kcb761h9-zY"]
+    @State private var snapshotImage: UIImage?
 
+    private func captureAndShareSnapshot() {
+        self.snapshotImage = ShareImage().snapshot()
+        if let image = self.snapshotImage {
+            print("스냅숏 이미지 확인.")
+            self.isSharing = true
+            print("Image size: \(image.size)")
+
+            let item = ImageMetadataProvider(placeholderItem: snapshotImage!)
+            self.showShareSheet(with: [item], isSharing: $isSharing)
+        } else {
+            print("Error ::: ")
+        }
+    }
     var body: some View {
-        Button {
-            isSharing = true
-            showShareSheet(with: itemsToShare, isSharing: $isSharing)
-        } label: {
-            Image(systemName: "square.and.arrow.up")
-                .font(.system(size: 20))
+        VStack {
+            Button {
+                isSharing = true
+                captureAndShareSnapshot()
+            } label: {
+                Image(systemName: "square.and.arrow.up")
+                    .font(.system(size: 20))
+            }
         }
     }
 }

--- a/Projects/Feature/Sources/MainView.swift
+++ b/Projects/Feature/Sources/MainView.swift
@@ -22,7 +22,7 @@ public struct MainView: View {
     public var body: some View {
         NavigationView {
             ZStack {
-                FieldView()
+                FieldBackgroundView()
                     .blur(radius: isSharing ? 10 : 0)
                 TeamInfo(team: someTeam)
                     .blur(radius: isSharing ? 10 : 0)
@@ -116,8 +116,8 @@ struct TeamInfo: View {
     }
 }
 
-// 필드 뷰, 딴의 작업물로 대체 예정
-struct FieldView: View {
+// 필드 백그라운드 뷰, 필드뷰 하단에 삽입 예정
+struct FieldBackgroundView: View {
 
     var body: some View {
         VStack {

--- a/Projects/Feature/Sources/MainView.swift
+++ b/Projects/Feature/Sources/MainView.swift
@@ -3,14 +3,18 @@
 //  App
 //
 //  Created by Ha Jong Myeong on 11/7/23.
+//  Copyright © 2023 com.pivoters. All rights reserved.
 //
+
 import Core
+import Common
 import SwiftUI
 
 public struct MainView: View {
 
     public init() {}
 
+    @State private var isSharing = false
     private var someTeam = Team(id: UUID(), teamName: "Newcastle United", subTitle: "2023-2024 Season", lineup: [])
     // 추후 model에서 반영 예정
     private var tintColor = Color.black
@@ -19,12 +23,19 @@ public struct MainView: View {
         NavigationView {
             ZStack {
                 FieldView()
+                    .blur(radius: isSharing ? 10 : 0)
                 TeamInfo(team: someTeam)
+                    .blur(radius: isSharing ? 10 : 0)
+                if isSharing {
+                    ShareView()
+                        .padding(.bottom, 400)
+                }
             }
             .ignoresSafeArea()
             .toolbar {
                 ToolbarItemGroup(placement: .topBarTrailing) {
-                    ShareButton()
+                    ShareButton(isSharing: $isSharing)
+                        .blur(radius: isSharing ? 10 : 0)
                 }
             }
         }
@@ -32,10 +43,16 @@ public struct MainView: View {
     }
 }
 
+// 공유 버튼
 struct ShareButton: View {
+    @Binding var isSharing: Bool
+    // 임시 링크, 이미지로 대체 예정
+    let itemsToShare = ["https://www.youtube.com/watch?v=Kcb761h9-zY"]
+
     var body: some View {
         Button {
-            print("tap!!")
+            isSharing = true
+            showShareSheet(with: itemsToShare, isSharing: $isSharing)
         } label: {
             Image(systemName: "square.and.arrow.up")
                 .font(.system(size: 20))
@@ -43,6 +60,7 @@ struct ShareButton: View {
     }
 }
 
+// 포메이션 텍스트
 struct FormationText: View {
 
     var body: some View {
@@ -60,6 +78,7 @@ struct FormationText: View {
     }
 }
 
+// 팀 정보 텍스트 섹션
 struct TeamInfo: View {
     let team: Team
 
@@ -89,11 +108,11 @@ struct TeamInfo: View {
     }
 }
 
+// 필드 뷰, 딴의 작업물로 대체 예정
 struct FieldView: View {
 
     var body: some View {
         VStack {
-            // 에셋으로 대체
             Color.blue.opacity(0.3)
                 .frame(height: 600)
             Spacer()

--- a/Projects/Feature/Sources/MainView.swift
+++ b/Projects/Feature/Sources/MainView.swift
@@ -4,16 +4,18 @@
 //
 //  Created by Ha Jong Myeong on 11/7/23.
 //
-
 import Core
 import SwiftUI
 
-struct MainView: View {
+public struct MainView: View {
+
+    public init() {}
+
     private var someTeam = Team(id: UUID(), teamName: "Newcastle United", subTitle: "2023-2024 Season", lineup: [])
     // 추후 model에서 반영 예정
     private var tintColor = Color.black
 
-    var body: some View {
+    public var body: some View {
         NavigationView {
             ZStack {
                 FieldView()

--- a/Projects/Feature/Sources/MainView.swift
+++ b/Projects/Feature/Sources/MainView.swift
@@ -49,18 +49,12 @@ struct ShareButton: View {
     @State private var snapshotImage: UIImage?
 
     private func captureAndShareSnapshot() {
-        self.snapshotImage = ShareImage().snapshot()
-        if let image = self.snapshotImage {
-            print("스냅숏 이미지 확인.")
-            self.isSharing = true
-            print("Image size: \(image.size)")
-
-            let item = ImageMetadataProvider(placeholderItem: snapshotImage!)
-            self.showShareSheet(with: [item], isSharing: $isSharing)
-        } else {
-            print("Error ::: ")
-        }
+        snapshotImage = ShareImage().snapshot()
+        isSharing = true
+        let metaData = ImageMetadataProvider(placeholderItem: snapshotImage!)
+        showShareSheet(with: [metaData], isSharing: $isSharing)
     }
+
     var body: some View {
         VStack {
             Button {

--- a/Projects/Feature/Sources/ShareView.swift
+++ b/Projects/Feature/Sources/ShareView.swift
@@ -11,12 +11,16 @@ import SwiftUI
 public struct ShareView: View {
 
     public init() {}
-    
+
     public var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        ShareImage()
     }
 }
 
-#Preview {
-    ShareView()
+struct ShareImage: View {
+
+    var body: some View {
+        Color.red
+            .frame(width: 200, height: 200)
+    }
 }

--- a/Projects/Feature/Sources/ShareView.swift
+++ b/Projects/Feature/Sources/ShareView.swift
@@ -1,0 +1,22 @@
+//
+//  ShareView.swift
+//  Feature
+//
+//  Created by Ha Jong Myeong on 11/8/23.
+//  Copyright © 2023 com.pivoters. All rights reserved.
+//
+
+import SwiftUI
+
+public struct ShareView: View {
+
+    public init() {}
+    
+    public var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    ShareView()
+}

--- a/Projects/Feature/Sources/ShareView.swift
+++ b/Projects/Feature/Sources/ShareView.swift
@@ -26,39 +26,3 @@ struct ShareImage: View {
             .frame(width: 200, height: 200)
     }
 }
-
-class ImageMetadataProvider: UIActivityItemProvider {
-  var image: UIImage
-
-  override var item: Any {
-    get {
-      return self.image
-    }
-  }
-
-  override init(placeholderItem: Any) {
-    guard let image = placeholderItem as? UIImage else {
-      fatalError("DEBUG ::: Couldn't create image from provided item")
-    }
-
-    self.image = image
-    super.init(placeholderItem: placeholderItem)
-  }
-
-  @available(iOS 13.0, *)
-  override func activityViewControllerLinkMetadata(_ activityViewController: UIActivityViewController) -> LPLinkMetadata? {
-
-    let metadata = LPLinkMetadata()
-    metadata.title = "Result Image"
-
-    var thumbnail: NSSecureCoding = NSNull()
-    if let imageData = self.image.pngData() {
-      thumbnail = NSData(data: imageData)
-    }
-
-    metadata.imageProvider = NSItemProvider(item: thumbnail, typeIdentifier: "public.png")
-
-    return metadata
-  }
-
-}

--- a/Projects/Feature/Sources/ShareView.swift
+++ b/Projects/Feature/Sources/ShareView.swift
@@ -6,7 +6,9 @@
 //  Copyright © 2023 com.pivoters. All rights reserved.
 //
 
+import Foundation
 import SwiftUI
+import LinkPresentation
 
 public struct ShareView: View {
 
@@ -23,4 +25,40 @@ struct ShareImage: View {
         Color.red
             .frame(width: 200, height: 200)
     }
+}
+
+class ImageMetadataProvider: UIActivityItemProvider {
+  var image: UIImage
+
+  override var item: Any {
+    get {
+      return self.image
+    }
+  }
+
+  override init(placeholderItem: Any) {
+    guard let image = placeholderItem as? UIImage else {
+      fatalError("DEBUG ::: Couldn't create image from provided item")
+    }
+
+    self.image = image
+    super.init(placeholderItem: placeholderItem)
+  }
+
+  @available(iOS 13.0, *)
+  override func activityViewControllerLinkMetadata(_ activityViewController: UIActivityViewController) -> LPLinkMetadata? {
+
+    let metadata = LPLinkMetadata()
+    metadata.title = "Result Image"
+
+    var thumbnail: NSSecureCoding = NSNull()
+    if let imageData = self.image.pngData() {
+      thumbnail = NSData(data: imageData)
+    }
+
+    metadata.imageProvider = NSItemProvider(item: thumbnail, typeIdentifier: "public.png")
+
+    return metadata
+  }
+
 }


### PR DESCRIPTION
## 🌁 Background
- App 모듈에 있던 MainView를 Feature 모듈로 변경했습니다.
- ShareView 기반 이미지 반출, 공유 기능을 구현했습니다.

## 📱 Screenshot
<img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-Pivoters/assets/36729917/0d34a350-1c78-45da-951b-b22e1a180e8b" width="200"/>

## 👩‍💻 Contents
- snapshot을 통한 커스텀 뷰 이미지 렌더링
``` swift
    /// SwiftUI 뷰의 스냅샷을 캡처하는 메소드
    func snapshot() -> UIImage? {
        let controller = UIHostingController(rootView: self)

        let view = controller.view
        let targetSize = CGSize(width: 200, height: 200)
        view?.frame = CGRect(origin: .zero, size: targetSize)
        view?.backgroundColor = .clear

        view?.layoutIfNeeded()

        // 내부적으로 렌더링 수행
        let renderer = UIGraphicsImageRenderer(size: targetSize)
        return renderer.image { _ in
            view?.drawHierarchy(in: controller.view.bounds, afterScreenUpdates: true)
        }
    }
```
- 공유시트에 메타데이터 전달 

``` swift
    public override func activityViewControllerLinkMetadata(
        _ activityViewController: UIActivityViewController
    ) -> LPLinkMetadata? {
        let metadata = LPLinkMetadata()
        metadata.title = "Titles" // 팀 이름으로 변경 예정
        metadata.originalURL = URL(fileURLWithPath: "Subtitles") // 포메이션 이름으로 변경 예정
        var thumbnail: NSSecureCoding = NSNull()
        if let imageData = self.image.pngData() {
            thumbnail = NSData(data: imageData)
        }

        metadata.imageProvider = NSItemProvider(item: thumbnail, typeIdentifier: "public.png")

        return metadata
    }
}
```


## ✅ Testing
- 상단 공유 아이콘 클릭시 메인뷰에 포함되어 있지 않은 요소(ShareImage() View)를 스냅샷 및 공유 시트에 메타데이터를 전달합니다.
- 블러 효과는 메인뷰에서 각 요소들을 블러 처리합니다.

## 📝 Review Note
- 블러 효과 처리의 더 나은 방법(각 요소를 블러처리 하는 것 외에 더 좋은 방법이 있을까요?)
- 공유 시트 모달이 올라올때(ActionViewController) 뒷 배경이 어두워 지는 효과를 조절할 수 있는 지 여부가 궁금하네요.
- ios17 의 문제로 해당 오류가 밝생하는데, 17.1 이후에선 발생하지 않는다 하니, 현 단계에선 무시해도 될 것 같습니다.

![image](https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-Pivoters/assets/36729917/71a2fd90-6198-4827-b7e8-6485635e7677)


## 📣 Related Issue
- close #15 