### PR TITLE
[Feat] 포메이션 기능 구현

### DIFF
--- a/Projects/Core/Sources/Models/Formation.swift
+++ b/Projects/Core/Sources/Models/Formation.swift
@@ -1,0 +1,9 @@
+//
+//  Formation.swift
+//  Core
+//
+//  Created by 한지석 on 11/15/23.
+//  Copyright © 2023 com.pivoters. All rights reserved.
+//
+
+import Foundation

--- a/Projects/Core/Sources/Models/Formation.swift
+++ b/Projects/Core/Sources/Models/Formation.swift
@@ -7,3 +7,28 @@
 //
 
 import Foundation
+
+public enum Formation: Int, Codable {
+    case five = 5
+    case six = 6
+    case eleven = 11
+
+    public var typeOfFormation: [TypeOfFormation] {
+        switch self {
+        case .five:
+            [TypeOfFormation.futsal22,
+             TypeOfFormation.futsal121]
+        case .six:
+            [TypeOfFormation.futsal32,
+             TypeOfFormation.futsal131,
+             TypeOfFormation.futsal212]
+        case .eleven:
+            [TypeOfFormation.football343,
+             TypeOfFormation.football442,
+             TypeOfFormation.football433,
+             TypeOfFormation.football4231,
+             TypeOfFormation.football4141,
+             TypeOfFormation.football523]
+        }
+    }
+}

--- a/Projects/Core/Sources/Models/Lineup.swift
+++ b/Projects/Core/Sources/Models/Lineup.swift
@@ -13,7 +13,8 @@ public final class Lineup {
 
     public let id: UUID
     public var uniform: Uniform
-    public var headcount: Headcount
+    public var formation: Formation
+    public var selectedTypeOfFormation: TypeOfFormation
     public var players: [Player]
     public var primaryColor: UniformColor
     public var secondaryColor: UniformColor
@@ -21,13 +22,15 @@ public final class Lineup {
     public init(
         id: UUID,
         uniform: Uniform,
-        headcount: Headcount,
+        formation: Formation,
+        selectedTypeOfFormation: TypeOfFormation,
         players: [Player],
         primaryColor: UniformColor,
         secondaryColor: UniformColor) {
             self.id = id
             self.uniform = uniform
-            self.headcount = headcount
+            self.formation = formation
+            self.selectedTypeOfFormation = selectedTypeOfFormation
             self.players = players
             self.primaryColor = primaryColor
             self.secondaryColor = secondaryColor
@@ -56,11 +59,4 @@ public enum Theme: Codable {
     case whiteGreen
     case blackBlue
     case grayBlack
-}
-
-public enum Headcount: Int, Codable {
-    case five = 5
-    case six = 6
-    case nine = 9
-    case eleven = 11
 }

--- a/Projects/Core/Sources/Models/TypeOfFormation.swift
+++ b/Projects/Core/Sources/Models/TypeOfFormation.swift
@@ -8,13 +8,13 @@
 
 import Foundation
 
-public enum FormationType: String {
-    case form343 = "3-4-3"
-    case form442 = "4-4-2"
-    case form433 = "4-3-3"
-    case form4231 = "4-2-3-1"
-    case form4141 = "4-1-4-1"
-    case form523 = "5-2-3"
+public enum TypeOfFormation: String {
+    case football343 = "3-4-3"
+    case football442 = "4-4-2"
+    case football433 = "4-3-3"
+    case football4231 = "4-2-3-1"
+    case football4141 = "4-1-4-1"
+    case football523 = "5-2-3"
 
     case form121 = "1-2-1"
     case form22 = "2-2"
@@ -25,7 +25,7 @@ public enum FormationType: String {
 
     public func returnPosition() -> [CGSize] {
         switch self {
-        case .form343:
+        case .football343:
             return [
                 CGSize(width: 0, height: 100),
                 CGSize(width: 0, height: 45), CGSize(width: -80, height: 45),
@@ -34,7 +34,7 @@ public enum FormationType: String {
                 CGSize(width: 130, height: -15), CGSize(width: 0, height: -80),
                 CGSize(width: -90, height: -80), CGSize(width: 90, height: -80)
             ]
-        case .form442:
+        case .football442:
             return [
                 CGSize(width: 0, height: 100),
                 CGSize(width: -50, height: 50), CGSize(width: 50, height: 50),
@@ -43,7 +43,7 @@ public enum FormationType: String {
                 CGSize(width: -140, height: -25), CGSize(width: 140, height: -25),
                 CGSize(width: -50, height: -80), CGSize(width: 50, height: -80)
             ]
-        case .form433:
+        case .football433:
             return [
                 CGSize(width: 0, height: 100),
                 CGSize(width: -50, height: 50), CGSize(width: 50, height: 50),
@@ -52,7 +52,7 @@ public enum FormationType: String {
                 CGSize(width: 70, height: -20), CGSize(width: 0, height: -80),
                 CGSize(width: -130, height: -80), CGSize(width: 130, height: -80)
             ]
-        case .form4231:
+        case .football4231:
             return [
                 CGSize(width: 0, height: 100),
                 CGSize(width: -50, height: 60), CGSize(width: 50, height: 60),
@@ -61,7 +61,7 @@ public enum FormationType: String {
                 CGSize(width: 0, height: -45), CGSize(width: -100, height: -45),
                 CGSize(width: 100, height: -45), CGSize(width: 0, height: -100)
             ]
-        case .form4141:
+        case .football4141:
             return [
                 CGSize(width: 0, height: 100),
                 CGSize(width: -50, height: 50), CGSize(width: 50, height: 50),
@@ -70,7 +70,7 @@ public enum FormationType: String {
                 CGSize(width: 50, height: -20), CGSize(width: -130, height: -30),
                 CGSize(width: 130, height: -30), CGSize(width: 0, height: -80)
             ]
-        case .form523:
+        case .football523:
             return [
                 CGSize(width: 0, height: 100),
                 CGSize(width: 0, height: 50), CGSize(width: -75, height: 50),

--- a/Projects/Core/Sources/Models/TypeOfFormation.swift
+++ b/Projects/Core/Sources/Models/TypeOfFormation.swift
@@ -16,12 +16,12 @@ public enum TypeOfFormation: String {
     case football4141 = "4-1-4-1"
     case football523 = "5-2-3"
 
-    case form121 = "1-2-1"
-    case form22 = "2-2"
+    case futsal121 = "1-2-1"
+    case futsal22 = "2-2"
 
-    case form32 = "3-2"
-    case form212 = "2-1-2"
-    case form131 = "1-3-1"
+    case futsal32 = "3-2"
+    case futsal212 = "2-1-2"
+    case futsal131 = "1-3-1"
 
     public func returnPosition() -> [CGSize] {
         switch self {
@@ -79,31 +79,31 @@ public enum TypeOfFormation: String {
                 CGSize(width: -50, height: -20), CGSize(width: 0, height: -80),
                 CGSize(width: 130, height: -80), CGSize(width: -130, height: -80)
             ]
-        case .form121:
+        case .futsal121:
             return [
                 CGSize(width: 0, height: 100),
                 CGSize(width: 0, height: 40), CGSize(width: -130, height: -15),
                 CGSize(width: 130, height: -15), CGSize(width: 0, height: -80)
             ]
-        case .form22:
+        case .futsal22:
             return [
                 CGSize(width: 0, height: 100),
                 CGSize(width: -130, height: 40), CGSize(width: 130, height: 40),
                 CGSize(width: -130, height: -80), CGSize(width: 130, height: -80)
             ]
-        case .form32:
+        case .futsal32:
             return [
                 CGSize(width: 0, height: 100), CGSize(width: 0, height: 40),
                 CGSize(width: -130, height: 40), CGSize(width: 130, height: 40),
                 CGSize(width: -80, height: -80), CGSize(width: 80, height: -80)
             ]
-        case .form212:
+        case .futsal212:
             return [
                 CGSize(width: 0, height: 100), CGSize(width: -130, height: 40),
                 CGSize(width: 130, height: 40), CGSize(width: 0, height: -15),
                 CGSize(width: -130, height: -80), CGSize(width: 130, height: -80)
             ]
-        case .form131:
+        case .futsal131:
             return [
                 CGSize(width: 0, height: 100), CGSize(width: 0, height: 40),
                 CGSize(width: 0, height: -15), CGSize(width: -130, height: -15),

--- a/Projects/Feature/Sources/Observable/FieldObservable.swift
+++ b/Projects/Feature/Sources/Observable/FieldObservable.swift
@@ -13,18 +13,19 @@ import Foundation
 class FieldObservable {
     var selectionPlayerIndex: Int?
     var lineup: Lineup = Lineup(id: UUID(),
-                                    uniform: .plain,
-                                    headcount: .eleven,
-                                    players: MockData.player,
-                                    primaryColor: UniformColor(red: 0.4,
-                                                               green: 0.4,
-                                                               blue: 0.4),
-                                    secondaryColor: UniformColor(red: 0.2,
-                                                                 green: 0.2,
-                                                                 blue: 0.2))
+                                uniform: .plain,
+                                formation: .eleven,
+                                selectedTypeOfFormation: .football433,
+                                players: MockData.player,
+                                primaryColor: UniformColor(red: 0.4,
+                                                           green: 0.4,
+                                                           blue: 0.4),
+                                secondaryColor: UniformColor(red: 0.2,
+                                                             green: 0.2,
+                                                             blue: 0.2))
     var theme: Theme = .blueGray
 
-    func changeFormation(_ formationType: FormationType) {
+    func changeFormation(_ formationType: TypeOfFormation) {
         let formationOffsets: [CGSize] = formationType.returnPosition()
 
         for index in 0..<formationOffsets.count {

--- a/Projects/Feature/Sources/Observable/TeamManagementObservable.swift
+++ b/Projects/Feature/Sources/Observable/TeamManagementObservable.swift
@@ -7,3 +7,16 @@
 //
 
 import Foundation
+
+import Core
+
+@Observable
+final class TeamManagementObservable {
+    var lineup: Lineup
+    var selectedTypeOfFormation: TypeOfFormation
+
+    init(lineup: Lineup) {
+        self.lineup = lineup
+        self.selectedTypeOfFormation = lineup.selectedTypeOfFormation
+    }
+}

--- a/Projects/Feature/Sources/Observable/TeamManagementObservable.swift
+++ b/Projects/Feature/Sources/Observable/TeamManagementObservable.swift
@@ -1,0 +1,9 @@
+//
+//  TeamManagementObservable.swift
+//  Feature
+//
+//  Created by 한지석 on 11/14/23.
+//  Copyright © 2023 com.pivoters. All rights reserved.
+//
+
+import Foundation

--- a/Projects/Feature/Sources/Observable/UniformObservable.swift
+++ b/Projects/Feature/Sources/Observable/UniformObservable.swift
@@ -17,7 +17,8 @@ public final class UniformObservable {
 
     var lineup = Lineup(id: UUID(),
                         uniform: .plain,
-                        headcount: .eleven,
+                        formation: .eleven,
+                        selectedTypeOfFormation: .football4231,
                         players: MockData.player,
                         primaryColor: UniformColor(red: 0.4,
                                                    green: 0.4,

--- a/Projects/Feature/Sources/View/FieldView.swift
+++ b/Projects/Feature/Sources/View/FieldView.swift
@@ -18,7 +18,7 @@ struct FieldView: View {
         ZStack {
             fieldObservable.theme.field
                 .offset(CGSize(width: 0, height: 100))
-            ForEach(0..<fieldObservable.lineup.headcount.rawValue, id: \.hashValue) { index in
+            ForEach(0..<fieldObservable.lineup.formation.rawValue, id: \.hashValue) { index in
                 if fieldObservable.lineup.players[index].isGoalkeeper {
                     PlayerView(theme: fieldObservable.theme, player: fieldObservable.lineup.players[index])
                           .offset(fieldObservable.lineup.players[index].offset.draggedOffset)

--- a/Projects/Feature/Sources/View/ModalSegmentedView.swift
+++ b/Projects/Feature/Sources/View/ModalSegmentedView.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 
+import Core
 import Common
 
 struct ModalSegmentedView: View {
@@ -39,12 +40,23 @@ struct ModalSegmentedView: View {
             case .player:
                 Text("Player")
             case .management:
-                TeamManagementView()
-                    .padding(.top, 24)
-                PlayerSelectionView(observable: PlayerSelectionObservable())
-                    .environment(fieldObservable)
-            case .squad:
-                Text("Squad")
+                TeamManagementView(
+                    observable: TeamManagementObservable(
+                        lineup: Lineup(id: UUID(),
+                                       uniform: .plain,
+                                       formation: .eleven,
+                                       selectedTypeOfFormation: .football4231,
+                                       players: MockData.player,
+                                       primaryColor: UniformColor(red: 0.4,
+                                                                  green: 0.4,
+                                                                  blue: 0.4),
+                                       secondaryColor: UniformColor(red: 0.2,
+                                                                    green: 0.2,
+                                                                    blue: 0.2)
+                                      )
+                    )
+                )
+                .padding(.top, 24)
             }
         }
         .frame(height: 450)

--- a/Projects/Feature/Sources/View/ModalSegmentedView.swift
+++ b/Projects/Feature/Sources/View/ModalSegmentedView.swift
@@ -23,7 +23,7 @@ struct ModalSegmentedView: View {
                 segmentedControl(buttonType: .theme)
                 segmentedControl(buttonType: .uniform)
                 segmentedControl(buttonType: .player)
-                segmentedControl(buttonType: .squad)
+                segmentedControl(buttonType: .management)
                 Spacer()
             }
             .padding(.horizontal, 20)
@@ -37,6 +37,10 @@ struct ModalSegmentedView: View {
                 UniformView(observable: UniformObservable())
                     .padding(.top, 24)
             case .player:
+                Text("Player")
+            case .management:
+                TeamManagementView()
+                    .padding(.top, 24)
                 PlayerSelectionView(observable: PlayerSelectionObservable())
                     .environment(fieldObservable)
             case .squad:
@@ -46,6 +50,7 @@ struct ModalSegmentedView: View {
         .frame(height: 450)
         .background(Color.white)
         .tint(Color.black)
+        .padding(.top, 8)
     }
 
     func segmentedControl(buttonType: EditType) -> some View {
@@ -64,7 +69,7 @@ enum EditType {
     case theme
     case uniform
     case player
-    case squad
+    case management
 
     var title: String {
         switch self {
@@ -74,8 +79,8 @@ enum EditType {
             "유니폼"
         case .player:
             "선수"
-        case .squad:
-            "스쿼드"
+        case .management:
+            "팀 관리"
         }
     }
 }

--- a/Projects/Feature/Sources/View/TeamManagementView.swift
+++ b/Projects/Feature/Sources/View/TeamManagementView.swift
@@ -12,8 +12,13 @@ import Common
 
 struct TeamManagementView: View {
 
-    let colors = ["4-3-3", "3-5-2", "4-4-2"]
-    @State var selectedColors = "4-3-3"
+//    let colors = ["4-3-3", "3-5-2", "4-4-2"]
+//    @State var selectedColors = "4-3-3"
+    @State var observable: TeamManagementObservable
+
+    init(observable: TeamManagementObservable) {
+        self.observable = observable
+    }
 
     var body: some View {
         VStack {
@@ -34,9 +39,9 @@ struct TeamManagementView: View {
                 .font(.Pretendard.semiBold14.font)
                 .tint(.colorBlack)
             Spacer()
-            Picker("포메이션", selection: $selectedColors) {
-                ForEach(colors, id: \.self) {
-                    Text($0)
+            Picker("포메이션", selection: $observable.selectedTypeOfFormation) {
+                ForEach(observable.lineup.formation.typeOfFormation, id: \.self) {
+                    Text($0.rawValue)
                         .font(.Pretendard.black14.font)
                 }
             }

--- a/Projects/Feature/Sources/View/TeamManagementView.swift
+++ b/Projects/Feature/Sources/View/TeamManagementView.swift
@@ -1,0 +1,19 @@
+//
+//  TeamManagementView.swift
+//  Feature
+//
+//  Created by 한지석 on 11/14/23.
+//  Copyright © 2023 com.pivoters. All rights reserved.
+//
+
+import SwiftUI
+
+struct TeamManagementView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    TeamManagementView()
+}

--- a/Projects/Feature/Sources/View/TeamManagementView.swift
+++ b/Projects/Feature/Sources/View/TeamManagementView.swift
@@ -14,6 +14,7 @@ struct TeamManagementView: View {
 
 //    let colors = ["4-3-3", "3-5-2", "4-4-2"]
 //    @State var selectedColors = "4-3-3"
+    @Environment(FieldObservable.self) var fieldObservable
     @State var observable: TeamManagementObservable
 
     init(observable: TeamManagementObservable) {
@@ -44,6 +45,9 @@ struct TeamManagementView: View {
                     Text($0.rawValue)
                         .font(.Pretendard.black14.font)
                 }
+            }
+            .onChange(of: observable.selectedTypeOfFormation) { _, selectedFormation in
+                fieldObservable.changeFormation(selectedFormation)
             }
             .tint(.gray)
             .pickerStyle(.menu)

--- a/Projects/Feature/Sources/View/TeamManagementView.swift
+++ b/Projects/Feature/Sources/View/TeamManagementView.swift
@@ -8,12 +8,41 @@
 
 import SwiftUI
 
-struct TeamManagementView: View {
-    var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
-    }
-}
+import Common
 
-#Preview {
-    TeamManagementView()
+struct TeamManagementView: View {
+
+    let colors = ["4-3-3", "3-5-2", "4-4-2"]
+    @State var selectedColors = "4-3-3"
+
+    var body: some View {
+        VStack {
+            RoundedRectangle(cornerRadius: 12)
+                .foregroundColor(Color(uiColor: .systemGray6))
+                .frame(height: 54)
+                .overlay {
+                    formationPicker
+                }
+                .padding(.horizontal, 20)
+            Spacer()
+        }
+    }
+
+    var formationPicker: some View {
+        HStack {
+            Text("포메이션")
+                .font(.Pretendard.semiBold14.font)
+                .tint(.colorBlack)
+            Spacer()
+            Picker("포메이션", selection: $selectedColors) {
+                ForEach(colors, id: \.self) {
+                    Text($0)
+                        .font(.Pretendard.black14.font)
+                }
+            }
+            .tint(.gray)
+            .pickerStyle(.menu)
+        }
+        .padding(.leading, 12)
+    }
 }


### PR DESCRIPTION
## 🌁 Background
- 포메이션을 세팅하는 기능을 구현했습니다.
- Enum으로 관리하는 플레이어 수, 포메이션 형태의 네이밍 수정을 진행했고 구조도 개선시켰습니다.

## 📱 Screenshot
<img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-Pivoters/assets/49385546/2785def7-46ae-471e-b637-f002c38e9033" width="200"/>
<img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-Pivoters/assets/49385546/984497ba-a744-49da-ab24-848200a27d2f" width="200"/>
<img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-Pivoters/assets/49385546/0c8b6770-0678-4516-abf1-059ded6f6089" width="200"/>

## 👩‍💻 Contents
- 팀 설정 View, Observable 생성(포메이션 수정의 상위)
- Formation(플레이어 수에 따른 포메이션 리턴) 구현
- TypeOfFormation(포메이션 리턴) 구현

## ✅ Testing
- 팀 관리 탭에서 피커로 수정해보십쇼!

## 📣 Related Issue
- close #42 
