### PR TITLE
[Feat] SwiftData를 통한 CRUD 구현

### DIFF
--- a/Projects/App/Sources/MyApp.swift
+++ b/Projects/App/Sources/MyApp.swift
@@ -5,14 +5,18 @@
 //  Created by Ha Jong Myeong on 10/7/23.
 //
 
-import SwiftUI
+
+import Core
 import Feature
+import SwiftData
+import SwiftUI
 
 @main
 struct MyApp: App {
     var body: some Scene {
         WindowGroup {
-            MainView()
+            AppContentView()
+                .modelContainer(teamContainer)
         }
     }
 }

--- a/Projects/Core/Sources/Models/RefactoredTeam.swift
+++ b/Projects/Core/Sources/Models/RefactoredTeam.swift
@@ -1,0 +1,27 @@
+//
+//  RefactoredTeam.swift
+//  Core
+//
+//  Created by Eojin Choi on 11/15/23.
+//  Copyright © 2023 com.pivoters. All rights reserved.
+//
+
+import Foundation
+import SwiftData
+
+@Model
+public final class RefactoredTeam {
+    public let id: UUID
+    public let teamName: String
+    public let subTitle: String
+
+    public init(
+        id: UUID,
+        teamName: String,
+        subTitle: String)
+    {
+        self.id = id
+        self.teamName = teamName
+        self.subTitle = subTitle
+    }
+}

--- a/Projects/Core/Sources/SwiftData/SwiftDataManager.swift
+++ b/Projects/Core/Sources/SwiftData/SwiftDataManager.swift
@@ -9,6 +9,22 @@
 import Foundation
 import SwiftData
 
+@MainActor
+public let teamContainer: ModelContainer = {
+    do {
+        let container = try ModelContainer(for: Team.self)
+        let context = container.mainContext
+        if try context.fetch(FetchDescriptor<Team>()).isEmpty {
+            container.mainContext.insert(Team(id: UUID(), teamName: "새 팀 1", subTitle: "새 서브 타이틀", lineup: [
+                /// Lineup 구현 3개 요구
+            ]))
+        }
+        return container
+    } catch {
+        fatalError(error.localizedDescription)
+    }
+}()
+
 public final class SwiftDataManager<T: PersistentModel> {
 
     private let modelContext: ModelContext
@@ -26,6 +42,14 @@ public final class SwiftDataManager<T: PersistentModel> {
         do {
             let items = try modelContext.fetch(FetchDescriptor<V>())
             return items
+        } catch {
+            fatalError(error.localizedDescription)
+        }
+    }
+    
+    public func saveItems() {
+        do {
+            try modelContext.save()
         } catch {
             fatalError(error.localizedDescription)
         }

--- a/Projects/Feature/Sources/Observable/RefactoredTeamObservable.swift
+++ b/Projects/Feature/Sources/Observable/RefactoredTeamObservable.swift
@@ -1,0 +1,9 @@
+//
+//  RefactoredTeamObservable.swift
+//  Feature
+//
+//  Created by Eojin Choi on 11/15/23.
+//  Copyright © 2023 com.pivoters. All rights reserved.
+//
+
+import Foundation

--- a/Projects/Feature/Sources/View/TeamCRUDView.swift
+++ b/Projects/Feature/Sources/View/TeamCRUDView.swift
@@ -1,0 +1,58 @@
+//
+//  TeamCRUDView.swift
+//  Feature
+//
+//  Created by Eojin Choi on 11/14/23.
+//  Copyright © 2023 com.pivoters. All rights reserved.
+//
+
+import Core
+import SwiftData
+import SwiftUI
+
+struct TeamCRUDView: View {
+    @Query private var teams: [Team]
+    
+    @Environment(\.modelContext) var context
+    @Bindable var observable: RefactoredTeamObservable
+    
+    @MainActor
+    public init(modelcontext: ModelContext) {
+        self.observable = RefactoredTeamObservable(modelContext: modelcontext)
+    }
+    
+    public var body: some View {
+        VStack {
+//            if let teams = observable.teams {
+            List {
+                ForEach(teams, id: \.self) { team in
+                    Text(team.teamName)
+                }
+                .onDelete(perform: deleteItems)
+                //                }
+            }
+            
+            HStack {
+                Button(action: addItem) {
+                    Text("추가")
+                }
+                .padding(.top, 10)
+                
+                Button(action: deleteLastItem) {
+                    Text("마지막 삭제")
+                }
+                .padding(.top, 10)
+            }
+        }
+    }
+    
+    func addItem() {
+        var newTeam = Team(id: UUID(), teamName: "새 팀", subTitle: "새 서브 타이틀", lineup: [])
+        observable.insertTeam(team: newTeam)
+        observable.teams = observable.fetchTeams()
+    }
+    
+    func deleteLastItem() { }
+    
+    func deleteItems(at offsets: IndexSet) { }
+}


### PR DESCRIPTION
## 🌁 Background
SwiftData를 Team 모델에 적용하기 위한 준비 사항을 구현했습니다.


## 📱 Screenshot
.


## 👩‍💻 Contents
- `SwiftDataManager.swift` 파일에서 `@Observable`과 `@Model` 매크로 등 기본 준비사항을 적용했습니다.
- `Team` 모델의 추가 및 뷰 업데이트를 테스트할 수 있는 `TeamCRUDView.swift` 파일을 생성했습니다.
- `MyApp.swift` 파일 내에 `.modelContainer()`로 mainContext를 전달하도록 추가했습니다.


## ✅ Testing
- `TeamCRUDView.swift` 파일을 통해 테스트 해 주시면 됩니다.
- 시뮬레이터를 종료하거나 초기화 시 SwiftData의 데이터 보존을 검증해 주시면 됩니다.


## 📝 Review Note
- SwiftData 너무 어렵습니다...


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #33


## 📬 Reference
- https://developer.apple.com/videos/play/wwdc2023/10187/
- https://developer.apple.com/videos/play/wwdc2023/10154/
- https://mixed-war-5dd.notion.site/SwiftData-Specific-ver-8295a40abfb7432ebb8620493619a390?pvs=4
