### PR TITLE
[Chore] SwiftData Team - Lineup 모델 의존 해결

### DIFF
--- a/Projects/Core/Sources/Models/RefactoredLineup.swift
+++ b/Projects/Core/Sources/Models/RefactoredLineup.swift
@@ -1,0 +1,66 @@
+//
+//  RefactoredLineup.swift
+//  Core
+//
+//  Created by Eojin Choi on 11/17/23.
+//  Copyright © 2023 com.pivoters. All rights reserved.
+//
+
+import Foundation
+import SwiftData
+
+@Model
+public final class RefactoredLineup {
+    public let id: UUID
+    public var lineupName: String
+    public var uniform: Uniform
+    public var formation: Formation
+//    public var selectedTypeOfFormation: TypeOfFormation
+//    public var players: [Player]
+    public var primaryColor: UniformColor
+    public var secondaryColor: UniformColor
+
+    public init(
+        id: UUID,
+        lineupName: String,
+        uniform: Uniform,
+        formation: Formation,
+//        selectedTypeOfFormation: TypeOfFormation,
+//        players: [Player],
+        primaryColor: UniformColor,
+        secondaryColor: UniformColor) {
+            self.id = id
+            self.lineupName = lineupName
+            self.uniform = uniform
+            self.formation = formation
+//            self.selectedTypeOfFormation = selectedTypeOfFormation
+//            self.players = players
+            self.primaryColor = primaryColor
+            self.secondaryColor = secondaryColor
+        }
+}
+
+//public struct UniformColor: Codable {
+//    public var red: Double
+//    public var green: Double
+//    public var blue: Double
+//
+//    public init(red: Double, green: Double, blue: Double) {
+//        self.red = red
+//        self.green = green
+//        self.blue = blue
+//    }
+//}
+
+//public enum Uniform: Codable {
+//    case plain
+//    case stripe
+//}
+
+//public enum Theme: Codable {
+//    case blueGray
+//    case whiteGreen
+//    case blackBlue
+//    case grayBlack
+//}
+

--- a/Projects/Core/Sources/Models/RefactoredTeam.swift
+++ b/Projects/Core/Sources/Models/RefactoredTeam.swift
@@ -15,6 +15,7 @@ public final class RefactoredTeam {
     public var teamName: String
     public var subTitle: String
     public var isSelected: Bool
+    public var lineups: [RefactoredLineup]
     public let createdAt: Date
     public var updatedAt: Date
 
@@ -23,12 +24,14 @@ public final class RefactoredTeam {
         teamName: String,
         subTitle: String,
         isSelected: Bool,
+        lineups: [RefactoredLineup],
         createdAt: Date,
         updatedAt: Date) {
             self.id = id
             self.teamName = teamName
             self.subTitle = subTitle
             self.isSelected = isSelected
+            self.lineups = lineups
             self.createdAt = createdAt
             self.updatedAt = updatedAt
         }

--- a/Projects/Core/Sources/SwiftData/SwiftDataManager.swift
+++ b/Projects/Core/Sources/SwiftData/SwiftDataManager.swift
@@ -20,6 +20,7 @@ public let teamContainer: ModelContainer = {
                                                         teamName: "새 팀 1",
                                                         subTitle: "새 서브 타이틀",
                                                         isSelected: true,
+                                                        lineups: [],
                                                         createdAt: Date(),
                                                         updatedAt: Date()))
         }

--- a/Projects/Feature/Sources/View/LineupCRUDView.swift
+++ b/Projects/Feature/Sources/View/LineupCRUDView.swift
@@ -1,0 +1,50 @@
+//
+//  LineupCRUDView.swift
+//  Feature
+//
+//  Created by Eojin Choi on 11/17/23.
+//  Copyright © 2023 com.pivoters. All rights reserved.
+//
+
+import Core
+import SwiftData
+import SwiftUI
+
+public struct LineupCRUDView: View {
+    var team: RefactoredTeam
+    
+    @Environment(\.modelContext) var context
+    
+    public var body: some View {
+        VStack {
+            List {
+                ForEach(team.lineups, id: \.self) { lineup in
+                    Text(lineup.lineupName)
+                }
+                .onDelete(perform: deleteLineup)
+            }
+            
+            HStack {
+                Button(action: {
+                }, label: {
+                    Text("라인업 추가")
+                })
+                .padding(.top, 10)
+            }
+        }
+    }
+    
+    func deleteLineup(at offsets: IndexSet) {
+        do {
+            for index in offsets {
+                let teamToDelete = team.lineups[index]
+                //            context.delete(teamToDelete)
+            }
+            team.lineups.remove(atOffsets: offsets)
+            
+            try context.save()
+        } catch {
+            print("error")
+        }
+    }
+}

--- a/Projects/Feature/Sources/View/TeamCRUDView.swift
+++ b/Projects/Feature/Sources/View/TeamCRUDView.swift
@@ -14,6 +14,7 @@ public struct TeamCRUDView: View {
     @Query private var teams: [RefactoredTeam]
     
     @Environment(\.modelContext) var context
+
     @State var observable: TeamSelectObservable
 
     @MainActor
@@ -23,39 +24,65 @@ public struct TeamCRUDView: View {
     }
     
     public var body: some View {
-        VStack {
-//            if let teams = observable.teams {
-            List {
-                ForEach(teams, id: \.self) { team in
-                    Text(team.teamName)
+        NavigationView {
+            VStack {
+                List {
+                    ForEach(teams, id: \.self) { team in
+                        NavigationLink(destination: LineupCRUDView(team: team)) {
+                            Text(team.teamName)
+                        }
+                    }
+                    .onDelete(perform: deleteTeam)
                 }
-                .onDelete(perform: deleteItems)
-                //                }
             }
             
             HStack {
                 Button(action: {
-                    observable.addTeam()
+                    context.insert(
+                        RefactoredTeam(
+                            id: UUID(),
+                            teamName: "새 팀 " + String(teams.count + 1),
+                            subTitle: "naldo",
+                            isSelected: true,
+                            lineups: [
+                                RefactoredLineup(
+                                    id: UUID(),
+                                    lineupName: "새 라인업 1",
+                                    uniform: .stripe,
+                                    formation: .eleven,
+                                    primaryColor: UniformColor(red: 0.3, green: 0.6, blue: 0.45),
+                                    secondaryColor: UniformColor(red: 0.8, green: 0.8, blue: 0.8)),
+                                RefactoredLineup(
+                                    id: UUID(),
+                                    lineupName: "새 라인업 2",
+                                    uniform: .stripe,
+                                    formation: .eleven,
+                                    primaryColor: UniformColor(red: 0.3, green: 0.6, blue: 0.45),
+                                    secondaryColor: UniformColor(red: 0.8, green: 0.8, blue: 0.8)),
+                                RefactoredLineup(
+                                    id: UUID(),
+                                    lineupName: "새 라인업 3",
+                                    uniform: .stripe,
+                                    formation: .eleven,
+                                    primaryColor: UniformColor(red: 0.3, green: 0.6, blue: 0.45),
+                                    secondaryColor: UniformColor(red: 0.8, green: 0.8, blue: 0.8)),
+                            ],
+                            createdAt: Date(),
+                            updatedAt: Date()))
                 }, label: {
-                    Text("추가")
+                    Text("팀 추가")
                 })
-                .padding(.top, 10)
-                
-                Button(action: deleteLastItem) {
-                    Text("마지막 삭제")
-                }
                 .padding(.top, 10)
             }
         }
     }
     
-//    func addItem() {
-//        var newTeam = Team(id: UUID(), teamName: "새 팀", subTitle: "새 서브 타이틀", lineup: [])
-//        observable.insertTeam(team: newTeam)
-//        observable.teams = observable.fetchTeams()
-//    }
-    
-    func deleteLastItem() { }
-    
-    func deleteItems(at offsets: IndexSet) { }
+    func deleteTeam(at offsets: IndexSet) {
+        for index in offsets {
+            let teamToDelete = teams[index]
+            context.delete(teamToDelete)
+        }
+    }
+
+
 }


### PR DESCRIPTION
## 🌁 Background
SwiftData에 Team - Lineup 모델의 관계가 적용되는 방식을 테스트하고 필요 사항들을 구현했습니다.


## 📱 Screenshot
.


## 👩‍💻 Contents
- `RefactoredTeam` 모델이 `SwiftDataManager.swift` 없이 SwiftData에서 저장되도록 일단 분리해서 구현했습니다.
- `RefactoredLineup` 모델을 분리해서 생성하고, `@Model` 매크로를 적용했습니다.
- `TeamCRUDView`에서 NavigationLink를 통해 `LineupCRUDView`로 연결되도록 했습니다.


## ✅ Testing
- `MyApp.swift` 파일에 연결되어 있는 `TeamCRUDView`에서 팀 생성 및 삭제를 테스트 해 주시면 됩니다.
- `TeamCRUDView`에서 리스트 아이템을 통해 `LineupCRUDView`에 접근했을 때 라인업 삭제 및 생성, 그리고 SwiftData 저장 여부를 테스트 해 주시면 됩니다.


## 📝 Review Note
.


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #56 


## 📬 Reference
.
