### PR TITLE
[Feat] 팀 변경 List, 팀 추가(팀명 / 스쿼드명 변경) UI 개선

### DIFF
--- a/Projects/Common/Sources/DesignSystem/Color+.swift
+++ b/Projects/Common/Sources/DesignSystem/Color+.swift
@@ -13,4 +13,5 @@ public extension Color {
     static let colorBlack = Color(red: 51 / 255, green: 51 / 255, blue: 51 / 255)
     static let colorWhite = Color(red: 255 / 255, green: 255 / 255, blue: 255 / 255)
     static let colorLightGray = Color(red: 204 / 255, green: 204 / 255, blue: 204 / 255)
+    static let colorBlue = Color(red: 0 / 255, green: 122 / 255, blue: 255 / 255)
 }

--- a/Projects/Common/Sources/DesignSystem/Font+.swift
+++ b/Projects/Common/Sources/DesignSystem/Font+.swift
@@ -11,6 +11,7 @@ import SwiftUI
 
 public extension Font {
     enum Pretendard {
+        case title
         case headerLarge
         case headerNormal
         case black14
@@ -23,6 +24,8 @@ public extension Font {
 
         public var font: Font {
             switch self {
+            case .title:
+                CommonFontFamily.Pretendard.bold.swiftUIFont(size: 24)
             case .headerLarge:
                 CommonFontFamily.Pretendard.black.swiftUIFont(size: 22)
             case .headerNormal:

--- a/Projects/Feature/Sources/Observable/TeamSelect/TeamSelectObservable.swift
+++ b/Projects/Feature/Sources/Observable/TeamSelect/TeamSelectObservable.swift
@@ -55,6 +55,9 @@ class TeamSelectObservable {
 
     func selectTeam(selectedTeam: Team) {
         for team in teams {
+            if team == selectedTeam {
+                team.updatedAt = Date()
+            }
             team.isSelected = selectedTeam == team
         }
         teams.sort { pre, _ in

--- a/Projects/Feature/Sources/View/Edit/ChangeTeamInfoView.swift
+++ b/Projects/Feature/Sources/View/Edit/ChangeTeamInfoView.swift
@@ -16,19 +16,23 @@ enum ChangeTeamInfo {
 struct ChangeTeamInfoView: View {
 
     @Environment(\.dismiss) var dismiss
-    @State var observable: ChangeTeamInfoObservable
+    @StateObject var observable: ChangeTeamInfoObservable
     let changeTeamInfo: ChangeTeamInfo
 
     init(observable: ChangeTeamInfoObservable,
          changeTeamInfo: ChangeTeamInfo) {
         self.changeTeamInfo = changeTeamInfo
         let observable = observable
-        _observable = State(initialValue: observable)
+        _observable = StateObject(wrappedValue: observable)
     }
 
     var body: some View {
         VStack(spacing: 0) {
             HStack {
+                Text(changeTeamInfo == .team ? "팀명 변경" : "스쿼드명 변경")
+                    .font(.Pretendard.title.font)
+                    .foregroundColor(.colorBlack)
+                    .padding(.top, 8)
                 Spacer()
                 Button {
                     dismiss()
@@ -41,16 +45,25 @@ struct ChangeTeamInfoView: View {
                 }
             }
             .padding(.top, 16)
-            .padding(.trailing, 16)
+            .padding(.horizontal, 16)
 
             TextField(changeTeamInfo == .team ? "팀 이름" : "스쿼드 이름", text: $observable.name)
                 .frame(height: 55)
                 .foregroundStyle(Color.colorBlack)
                 .font(.Pretendard.headerNormal.font)
                 .textFieldStyle(PlainTextFieldStyle())
-                .padding(.horizontal, 24)
+                .padding(.horizontal, 16)
+                .padding(.top, 16)
+                .onReceive(observable.name.publisher.collect()) {
+                    if $0.count > 15 {
+                        observable.name = String($0.prefix(15))
+                    }
+                }
+                .onAppear {
+                    UITextField.appearance().clearButtonMode = .whileEditing
+                }
             Divider()
-                .padding(.horizontal, 24)
+                .padding(.horizontal, 16)
             Spacer()
             Button {
                 // MARK: createTeam
@@ -58,7 +71,7 @@ struct ChangeTeamInfoView: View {
                 dismiss()
             } label: {
                 RoundedRectangle(cornerRadius: 12)
-                    .foregroundStyle(Color(red: 0 / 255, green: 122 / 255, blue: 255 / 255))
+                    .foregroundStyle(observable.isButtonEnabled ? Color.colorBlue : Color.colorLightGray)
                     .frame(height: 60)
                     .padding(.horizontal, 20)
                     .overlay {
@@ -68,6 +81,13 @@ struct ChangeTeamInfoView: View {
                     }
             }
             .padding(.bottom, 20)
+            .disabled(!observable.isButtonEnabled)
+        }
+        .submitLabel(.done)
+        .onSubmit {
+            guard observable.isButtonEnabled else { return }
+            observable.changeName()
+            dismiss()
         }
     }
 }

--- a/Projects/Feature/Sources/View/TeamSelect/TeamCell.swift
+++ b/Projects/Feature/Sources/View/TeamSelect/TeamCell.swift
@@ -24,10 +24,22 @@ struct TeamCell: View {
 
     var body: some View {
         HStack(alignment: .center) {
-            Image(asset: CommonAsset.uniform)
-                .resizable()
-                .frame(width: 36, height: 36)
-                .padding(.leading, 34)
+            if let team = team {
+                let lineup = team.lineup.filter { $0.index == 0 }.first
+                if let lineup = lineup {
+                    OverlapUniform(uniform: lineup.uniform,
+                                   uniformSize: 36,
+                                   primaryColor: lineup.primaryColor,
+                                   secondaryColor: lineup.secondaryColor,
+                                   isSelected: false)
+                        .padding(.leading, 34)
+                }
+            } else {
+                Image(asset: CommonAsset.uniform)
+                    .resizable()
+                    .frame(width: 36, height: 36)
+                    .padding(.leading, 34)
+            }
             Spacer()
             Text(cellType == .select ? team!.teamName : "+ 새로운 팀 추가")
                 .foregroundStyle(cellType == .select ? Color.colorBlack : Color.colorLightGray)
@@ -39,7 +51,7 @@ struct TeamCell: View {
         .overlay {
             if isSelected {
                 RoundedRectangle(cornerRadius: 8)
-                    .stroke(Color.colorLightGray, lineWidth: 1.5)
+                    .stroke(Color.colorBlue, lineWidth: 1.5)
                     .padding(1)
             }
         }

--- a/Projects/Feature/Sources/View/TeamSelect/TeamCreateView.swift
+++ b/Projects/Feature/Sources/View/TeamSelect/TeamCreateView.swift
@@ -11,13 +11,17 @@ import SwiftUI
 struct TeamCreateView: View {
 
     @Environment(\.dismiss) var dismiss
-    @State var observable: TeamCreateObservable
+    @StateObject var observable: TeamCreateObservable
 
     let limitTeamName: Int = 15
 
     var body: some View {
         VStack(spacing: 0) {
             HStack {
+                Text("팀 추가")
+                    .font(.Pretendard.title.font)
+                    .foregroundColor(.colorBlack)
+                    .padding(.top, 8)
                 Spacer()
                 Button {
                     dismiss()
@@ -30,21 +34,25 @@ struct TeamCreateView: View {
                 }
             }
             .padding(.top, 16)
-            .padding(.trailing, 16)
+            .padding(.horizontal, 16)
 
             TextField("팀명", text: $observable.teamName)
                 .frame(height: 55)
                 .foregroundStyle(Color.colorBlack)
                 .font(.Pretendard.headerNormal.font)
                 .textFieldStyle(PlainTextFieldStyle())
-                .padding(.horizontal, 24)
-                .onReceive(observable.teamName.publisher.collect(), perform: { newText in
-                    if newText.count > limitTeamName {
-                        observable.teamName = String(newText.prefix(limitTeamName))
+                .padding(.horizontal, 16)
+                .padding(.top, 16)
+                .onReceive(observable.teamName.publisher.collect()) {
+                    if $0.count > limitTeamName {
+                        observable.teamName = String($0.prefix(limitTeamName))
                     }
-                })
+                }
+                .onAppear {
+                    UITextField.appearance().clearButtonMode = .whileEditing
+                }
             Divider()
-                .padding(.horizontal, 24)
+                .padding(.horizontal, 16)
             Spacer()
             Button {
                 // MARK: createTeam
@@ -52,14 +60,23 @@ struct TeamCreateView: View {
                 dismiss()
             } label: {
                 RoundedRectangle(cornerRadius: 12)
-                    .foregroundStyle(Color.indigo)
+                    .foregroundStyle(observable.isButtonEnabled ? Color.colorBlue : Color.colorLightGray)
                     .frame(height: 60)
-                    .padding(.horizontal, 20)
+                    .padding(.horizontal, 16)
                     .overlay {
                         Text("추가")
+                            .font(.Pretendard.headerNormal.font)
+                            .foregroundColor(Color.white)
                     }
             }
             .padding(.bottom, 20)
+            .disabled(!observable.isButtonEnabled)
+        }
+        .submitLabel(.done)
+        .onSubmit {
+            guard observable.isButtonEnabled else { return }
+            observable.createTeam()
+            dismiss()
         }
 
     }

--- a/Projects/Feature/Sources/View/TeamSelect/TeamSelectView.swift
+++ b/Projects/Feature/Sources/View/TeamSelect/TeamSelectView.swift
@@ -20,6 +20,10 @@ struct TeamSelectView: View {
         VStack(spacing: 0) {
             // MARK: 상단 X Button
             HStack {
+                Text("팀 변경")
+                    .font(.Pretendard.title.font)
+                    .foregroundColor(.colorBlack)
+                    .padding(.top, 8)
                 Spacer()
                 Button {
                     if observable.currentPresentationDetent == .large {
@@ -36,7 +40,7 @@ struct TeamSelectView: View {
                 }
             }
             .padding(.top, 16)
-            .padding(.trailing, 16)
+            .padding(.horizontal, 16)
 
             if observable.currentPresentationDetent == .fraction(0.5) {
                 HStack {
@@ -46,7 +50,7 @@ struct TeamSelectView: View {
                     } label: {
                         Text("더 보기")
                             .font(.Pretendard.semiBold14.font)
-                            .foregroundStyle(Color.colorBlack)
+                            .foregroundStyle(Color.colorBlue)
                     }
                     .padding(.top, 16)
                     .padding(.bottom, 8)
@@ -114,6 +118,7 @@ struct TeamSelectView: View {
         .listRowSpacing(12)
         .background(.regularMaterial)
         .scrollContentBackground(.hidden)
+        .scrollIndicators(.hidden)
     }
 
     var detailTeamList: some View {


### PR DESCRIPTION
## 🌁 Background
- 팀 변경 리스트가 직관적이지 않은 문제가 있었습니다.
- 팀명 추가(팀명 / 스쿼드명 변경) 페이지에서 텍스트 필드의 문자가 없어도 등록되는 문제가 있었습니다.

## 📱 Screenshot
<img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-Pivoters/assets/49385546/20fbfb2f-c06c-4b0a-9983-367dcdf3ff45" width="200"/>
<img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-Pivoters/assets/49385546/f4f35def-2525-4ef4-af70-1600f68c34eb" width="200"/>
<img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-Pivoters/assets/49385546/bc30c595-9d19-45c5-a584-fdf1687864bd" width="200"/>

## 👩‍💻 Contents
- 폰트, 컬러 추가
- 텍스트필드 Combine 적용(버튼 활성/비활성화)
- 화면 타이틀 추가
- 팀 변경 셀 유니폼 미리보기 추가
- 팀 변경 셀 정렬을 위한 updateAt 업데이트 하도록 구현

## 📣 Related Issue
- close #76 
