### PR TITLE
[Feat] 메인 뷰 선수 선택 기능

### DIFF
--- a/Projects/Feature/Sources/Observable/Main/FieldObservable.swift
+++ b/Projects/Feature/Sources/Observable/Main/FieldObservable.swift
@@ -6,12 +6,12 @@
 //  Copyright © 2023 com.pivoters. All rights reserved.
 //
 
-import Core
 import Foundation
+
+import Core
 
 @Observable
 class FieldObservable {
-
     var team: Team
     var lineup: Lineup
     var players: [Player] = [Player]()

--- a/Projects/Feature/Sources/View/Main/FieldView.swift
+++ b/Projects/Feature/Sources/View/Main/FieldView.swift
@@ -15,6 +15,8 @@ struct FieldView: View {
     var observable: FieldObservable
     var isShowEditSheet: Bool
     @Binding var editType: EditType
+    @Binding var currentPresentationDetent: PresentationDetent
+
     let noneGesture = DragGesture()
         .onChanged { _ in
             print("onChange")
@@ -41,6 +43,7 @@ struct FieldView: View {
                         if observable.lineup.selectionPlayerIndex == index {
                             observable.lineup.selectionPlayerIndex = nil
                         } else {
+                            currentPresentationDetent = .height(CGFloat.editHeight)
                             observable.lineup.selectionPlayerIndex = index
                             editType = .player
                         }
@@ -90,6 +93,7 @@ struct FieldView: View {
                         if observable.lineup.selectionPlayerIndex == index {
                             observable.lineup.selectionPlayerIndex = nil
                         } else {
+                            currentPresentationDetent = .height(CGFloat.editHeight)
                             observable.lineup.selectionPlayerIndex = index
                             editType = .player
                         }

--- a/Projects/Feature/Sources/View/Main/MainView.swift
+++ b/Projects/Feature/Sources/View/Main/MainView.swift
@@ -106,7 +106,7 @@ public struct MainView: View {
                 observable.fetchTeam()
             }
         }
-        .onChange(of: mainObservable.currentPresentationDetent, { oldValue, newValue in
+        .onChange(of: mainObservable.currentPresentationDetent, { _, newValue in
             if newValue == .height(.defaultHeight) {
                 observable.lineup.map { $0.selectionPlayerIndex = nil }
             }
@@ -131,6 +131,7 @@ struct ModalDefaultView: View {
     var body: some View {
         VStack {
             Image(asset: CommonAsset.upperArrow)
+                .renderingMode(.template)
                 .foregroundStyle(teamObservable.lineup[mainObservable.currentIndex].theme.textColor)
                 .padding(.top, 24)
             Text(String(localized: "Push To Edit"))

--- a/Projects/Feature/Sources/View/Main/MainView.swift
+++ b/Projects/Feature/Sources/View/Main/MainView.swift
@@ -106,6 +106,11 @@ public struct MainView: View {
                 observable.fetchTeam()
             }
         }
+        .onChange(of: mainObservable.currentPresentationDetent, { oldValue, newValue in
+            if newValue == .height(.defaultHeight) {
+                observable.lineup.map { $0.selectionPlayerIndex = nil }
+            }
+        })
         .onAppear {
             DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
                 withAnimation {
@@ -149,9 +154,11 @@ struct FieldCarousel: View {
                      visibleEdgeSpace: -120,
                      spacing: -30,
                      mainObservable: mainObservable) { index in
-                FieldView(observable: FieldObservable(team: team, lineup: lineup[index]),
+                FieldView(observable: FieldObservable(team: team,
+                                                      lineup: lineup[index]),
                           isShowEditSheet: mainObservable.currentPresentationDetent == .height(CGFloat.editHeight),
-                          editType: $editType)
+                          editType: $editType,
+                          currentPresentationDetent: $mainObservable.currentPresentationDetent)
             }
                      .frame(height: UIScreen.main.bounds.size.height * 0.4)
                      .animation(.spring, value: mainObservable.currentPresentationDetent)


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
메인 뷰에서 선수 선택 기능에 대한 PR입니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 메인 뷰에서 선수 클릭 시 선수 선택, 편집 가능한 시트가 올라오도록 구현 했습니다.
- 약간의 디자인 수정을 했습니다.

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #112 
