### PR TITLE
[Bug] 풋살일경우 공유 사진 버그 해결

### DIFF
--- a/Projects/Feature/Sources/View/Edit/ShareView.swift
+++ b/Projects/Feature/Sources/View/Edit/ShareView.swift
@@ -46,6 +46,14 @@ public struct ShareImage: View {
     var isSharing: Bool
     var lineup: Lineup
     let deviceHeight = UIScreen.main.bounds.height
+    var players: [Player]
+
+    init(team: Team? = nil, isSharing: Bool, lineup: Lineup) {
+        self.team = team
+        self.isSharing = isSharing
+        self.lineup = lineup
+        self.players = self.lineup.players.sorted { $0.number < $1.number }
+    }
 
     public var body: some View {
         if isSharing {
@@ -71,11 +79,11 @@ public struct ShareImage: View {
                 .padding(.top, (deviceHeight <= 800) ? deviceHeight * 0.04 : deviceHeight * 0.022)
                 ForEach(0..<lineup.formation.rawValue, id: \.hashValue) { index in
                     PlayerView(theme: lineup.theme,
-                               player: lineup.players[index],
+                               player: players[index],
                                lineup: lineup,
                                index: 100)
-                    .offset(CGSize(width: lineup.players[index].offset.draggedOffsetWidth,
-                                   height: lineup.players[index].offset.draggedOffsetHeight))
+                    .offset(CGSize(width: players[index].offset.draggedOffsetWidth,
+                                   height: players[index].offset.draggedOffsetHeight))
                 }
                 .padding(.top, (deviceHeight <= 800) ? deviceHeight * 0.17 : deviceHeight * 0.08)
             }


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
풋살 인원으로 변경 시 shareView 버그 발생 한 것을 해결했습니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 버그 해결

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
인원을 풋살로 교체 후 공유하기 기능 실행 해보면 됩니다 :)

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #119 
