### PR TITLE
fix: 플레이어 이미지 탭 시 캐러셀 스크롤 문제 수정(#138)

### DIFF
--- a/Projects/Feature/Sources/View/Main/FieldView.swift
+++ b/Projects/Feature/Sources/View/Main/FieldView.swift
@@ -96,7 +96,7 @@ struct FieldView: View {
                                 accumulatedOffsetHeight > 0 ?
                                 min(accumulatedOffsetHeight, 120): max(accumulatedOffsetHeight, -110)
                             }:
-                            noneGesture
+                            nil
 
                     )
                     .onTapGesture {


### PR DESCRIPTION
## 🌁 Background
- 선수 이미지에 탭을 한 채로, Carousel 스크롤 시 스크롤이 넘어가지 않는 반응을 개선합니다.

## 📱 Screenshot
https://github.com/DeveloperAcademy-POSTECH/MacC-Team10-Pivoters/assets/36729917/25f5a191-75cd-4cfc-b92b-d81ef7be7600

(시뮬레이터 빌드라 버벅임이 있습니다😂)

## 👩‍💻 Contents
- 이것저것 삽질을 하다 .. 코드 한줄로 FieldView에 PlayerView 쪽에 걸려있는 noneGeture -> nil로 변경하는 것으로 해결하였습니다 

## ✅ Testing
- 메인뷰에서 선수 이미지에 탭을 한채로, 좌우 스크롤 테스트

## 📝 Review Note
- 해당 이슈를 해결하다, **메인뷰에서 선수를 옮기면 어떨까 해서, 테스트 해보았는데 꽤 사용성이 좋아서 이 부분은 적극적으로 사용성 테스트 한번 해봐도 좋을 것 같아요.** (선수 위치 이동 기능을 유저가 자주, 많이 사용한다는 가정이 되어야 할 것 같습니다!)
   ** FieldView에서 71번째 라인에 걸려있는 조건문 해제, 99번 라인 nil(기존 noneGesture) 제거하시면 됩니다!

- Carousel 내부에서 해결을 시도하려 두 제스쳐가 중첩 될때 사용하는 simultaneous gesture를 이용하려 했는데,
   FIeldView를 그대로 Carousel에 적용하는 방식 때문에, 해당 방식은 적합하지 않다고 판단했습니다!
   
 - 추후 Carousel 복잡도를 해소하기 위해, 메인뷰에 사용되는 FieldView를 이미지화 하기 위해서, 개별적으로 snapshot을 적용하는 방법도
    좋을 것 같아요.

## 📣 Related Issue
- close #138 

